### PR TITLE
removed mentioning of headnode

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
   <li>Ready-to-use management console from FIFO.</li>
   <li>Nearly 100% resource utilization of hardware.</li>
   <li>No installation time for Resource Node (a.k.a chunter node).</li>
-  <li>Guided, fast (&lt; 10min) provision of management VM for Head Node (a.k.a fifo zone node), and works even without Internet access.</li>
+  <li>Guided, fast (&lt; 10min) provision of the first FiFo (management) zone, and works even without Internet access.</li>
 </ul>
 
 <p>DogeOS is, as similar to Project FiFo and SmartOS, licensed under <a href="http://smartos.org/cddl/">CDDL</a>. Generally, it is free of use.</p>


### PR DESCRIPTION
FiFo does not have the concept of a headnode, this phrases it a bit better to also indicate that there can be more then one FiFo zone
